### PR TITLE
Add multiline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,19 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-nom = "7"
+nom = "8"
 thiserror = "1"
 
 [dev-dependencies]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,8 @@
 /// de
-use crate::{parse, Key};
+use crate::{parse, Key, Value};
 use nom::Finish;
 use serde::de::{self, IntoDeserializer, SeqAccess};
-use std::{error, fmt, num::ParseIntError};
+use std::{borrow::Cow, error, fmt, num::ParseIntError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -14,6 +14,7 @@ pub enum Error {
     ExpectChar(parse::de::OwnedKey),
     ExpectNum(ParseIntError),
     ExpectIdent(String),
+    ExpectStr(String),
     Unsupported(&'static str),
 }
 
@@ -50,6 +51,7 @@ impl fmt::Display for Error {
             Error::ExpectBool(key) => write!(fmt, "expected bool, found {:?}", key),
             Error::ExpectChar(key) => write!(fmt, "expected char, found {:?}", key),
             Error::ExpectNum(key) => write!(fmt, "expected number, found {:?}", key),
+            Error::ExpectStr(key) => write!(fmt, "expected string, found {:?}", key),
             Error::ExpectIdent(key) => write!(fmt, "expected number, found {:?}", key),
             Error::Unsupported(s) => write!(fmt, "{s} is not unsupported"),
         }
@@ -82,6 +84,12 @@ impl<'de> Deserializer<'de> {
         let (input, key) = parse::key_like(self.input).finish()?;
         self.input = input;
         Ok(key)
+    }
+
+    fn parse_value(&mut self) -> Result<parse::Value<'de>, Error> {
+        let (input, value) = parse::value(self.input).finish()?;
+        self.input = input;
+        Ok(value)
     }
 
     fn parse_ident(&mut self) -> Result<parse::de::Ident<'de>, Error> {
@@ -243,10 +251,12 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: de::Visitor<'de>,
     {
-        let value = self.parse_key_like()?;
+        let value = self.parse_value()?;
         match value {
-            Key::Str(v) => visitor.visit_borrowed_str(v),
-            Key::Num(v) => visitor.visit_str(v.to_string().as_str()),
+            Value::Str(Cow::Borrowed(v)) => visitor.visit_borrowed_str(v),
+            Value::Str(Cow::Owned(v)) => visitor.visit_string(v),
+            Value::Num(v) => visitor.visit_str(v.to_string().as_str()),
+            _ => Err(Error::ExpectStr(self.input.to_string())),
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,16 +2,16 @@
 use nom::{
     branch::alt,
     bytes::complete::take_while,
-    character::{
-        complete::{alpha1, char, digit1, line_ending, multispace0, not_line_ending, space0},
-        is_alphanumeric, is_space,
+    character::complete::{
+        alpha1, char, digit1, line_ending, multispace0, not_line_ending, space0,
     },
-    combinator::{map, map_res, opt, peek},
+    combinator::{map, map_res, opt},
+    error::ParseError,
     multi::{many0, many1, separated_list1},
-    sequence::{delimited, pair, preceded, terminated, tuple},
-    IResult,
+    sequence::{delimited, pair, preceded, terminated},
+    AsChar, IResult, Parser,
 };
-use std::{collections::HashMap, iter::FromIterator, str};
+use std::{borrow::Cow, collections::HashMap, fmt::Debug, iter::FromIterator, str};
 
 pub type Group<'a> = HashMap<Key<'a>, Value<'a>>;
 
@@ -22,7 +22,7 @@ pub type Error<'a> = nom::error::Error<&'a str>;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Value<'a> {
     Num(i64),
-    Str(&'a str),
+    Str(Cow<'a, str>),
     Array(Vec<Value<'a>>),
 }
 
@@ -47,7 +47,7 @@ impl<'a> From<&'a str> for Key<'a> {
 impl<'a> From<Key<'a>> for Value<'a> {
     fn from(value: Key<'a>) -> Self {
         match value {
-            Key::Str(s) => Value::Str(s),
+            Key::Str(s) => Value::Str(Cow::Borrowed(s)),
             Key::Num(n) => Value::Num(n),
         }
     }
@@ -57,14 +57,37 @@ pub(crate) fn eol(i: &str) -> IResult<&str, Option<&str>> {
     let (rest, (comment, _)) = pair(
         opt(preceded(pair(multispace0, char(';')), not_line_ending)),
         many1(line_ending),
-    )(i)?;
+    )
+    .parse(i)?;
     Ok((rest, comment))
 }
 
-// TODO allow underscore!
+pub(crate) fn backslash(i: &str) -> IResult<&str, char> {
+    map(
+        (multispace0, char('\\'), space0, line_ending, space0),
+        |(_, slash, _, _, _)| slash,
+    )
+    .parse(i)
+}
+
+pub(crate) fn multiline(i: &str) -> IResult<&str, String> {
+    map(
+        preceded(backslash, separated_list1(backslash, space_separated)),
+        |result| {
+            result
+                .into_iter()
+                .map(|l| match l {
+                    "" => "\n",
+                    l => l,
+                })
+                .collect()
+        },
+    )
+    .parse(i)
+}
+
 pub(crate) fn space_separated(i: &str) -> IResult<&str, &str> {
-    let (i, result) = take_while(|c| is_alphanumeric(c as u8) || is_space(c as u8) || c == '_')(i)?;
-    Ok((i, result.trim_end()))
+    take_while(|c| AsChar::is_alphanum(c as u8) || AsChar::is_space(c as u8) || c == '_')(i)
 }
 
 pub(crate) fn key_like(i: &str) -> IResult<&str, Key> {
@@ -72,54 +95,63 @@ pub(crate) fn key_like(i: &str) -> IResult<&str, Key> {
         multispace0,
         alt((
             map_res(digit1, |s| str::parse::<i64>(s).map(Key::Num)),
-            map(space_separated, Key::Str),
+            map(space_separated, |val| Key::Str(val.trim_end())),
         )),
-    )(i)
+    )
+    .parse(i)
 }
 
 pub(crate) fn values(i: &str) -> IResult<&str, Vec<Value>> {
-    separated_list1(char(','), map(key_like, Value::from))(i)
+    let (i, vec) = separated_list1(char(','), map(key_like, Value::from)).parse(i)?;
+    match vec.len() {
+        0..2 => Err(nom::Err::Error(nom::error::Error::from_error_kind(
+            i,
+            nom::error::ErrorKind::SeparatedNonEmptyList,
+        ))),
+        2.. => Ok((i, vec)),
+    }
 }
 
 pub(crate) fn value(i: &str) -> IResult<&str, Value> {
-    match peek(terminated(key_like, char(',')))(i).is_ok() {
-        true => map(values, Value::Array)(i),
-        false => map(key_like, Value::from)(i),
-    }
+    alt((
+        terminated(map(multiline, |s| Value::Str(Cow::Owned(s))), eol),
+        terminated(map(values, Value::Array), eol),
+        terminated(map(key_like, Value::from), eol),
+    ))
+    .parse(i)
 }
 
 pub(crate) fn key_value(i: &str) -> IResult<&str, (Key, Value)> {
     pair(
         key_like,
-        preceded(tuple((opt(space0), char('='), opt(space0))), value),
-    )(i)
+        preceded((opt(space0), char('='), opt(space0)), value),
+    )
+    .parse(i)
 }
 
 pub(crate) fn key_values(i: &str) -> IResult<&str, Group> {
-    map(
-        many0(terminated(key_value, opt(eol))),
-        FromIterator::from_iter,
-    )(i)
+    map(many0(key_value), FromIterator::from_iter).parse(i)
 }
 
 pub(crate) fn section(i: &str) -> IResult<&str, (&str, Option<&str>)> {
-    delimited(
-        char('['),
-        pair(space_separated, opt(preceded(char(' '), alpha1))),
-        char(']'),
-    )(i)
+    terminated(
+        delimited(
+            char('['),
+            pair(space_separated, opt(preceded(char(' '), alpha1))),
+            char(']'),
+        ),
+        eol,
+    )
+    .parse(i)
 }
 
 pub(crate) fn group(i: &str) -> IResult<&str, (&str, Group)> {
-    pair(
-        map(terminated(section, opt(eol)), |(cat, _meta)| cat),
-        key_values,
-    )(i)
+    pair(map(section, |(cat, _meta)| cat), key_values).parse(i)
 }
 
 pub(crate) fn tables(i: &str) -> IResult<&str, Sections> {
-    let (_i, (anon, mut named)): (_, (_, Sections)) =
-        pair(opt(key_values), map(many0(group), FromIterator::from_iter))(i)?;
+    let (i, (anon, mut named)): (_, (_, Sections)) =
+        pair(opt(key_values), map(many0(group), FromIterator::from_iter)).parse(i)?;
     if let Some(map) = anon {
         named.insert("_", map);
     }
@@ -133,8 +165,8 @@ pub(crate) mod de {
         branch::alt,
         character::complete::{char, multispace0, space0},
         combinator::{map, opt, peek},
-        sequence::{preceded, terminated, tuple},
-        IResult,
+        sequence::{preceded, terminated},
+        IResult, Parser,
     };
     use std::{error, fmt};
 
@@ -184,15 +216,17 @@ pub(crate) mod de {
     }
 
     pub(crate) fn peek_ident(i: &str) -> Option<Ident> {
-        peek(opt(ident))(i).map_or(None, |(_, ident)| ident)
+        peek(opt(ident)).parse(i).map_or(None, |(_, ident)| ident)
     }
 
     pub(crate) fn peek_eof(i: &str) -> bool {
-        peek(skip_end)(i).map_or_else(|_| false, |(rest, parsed)| rest.len() == parsed.len())
+        peek(skip_end)
+            .parse(i)
+            .map_or_else(|_| false, |(rest, parsed)| rest.len() == parsed.len())
     }
 
     pub(crate) fn peek_eol(i: &str) -> bool {
-        peek(eol)(i).map_or_else(|_| false, |_| true)
+        peek(eol).parse(i).map_or_else(|_| false, |_| true)
     }
 
     pub(crate) fn ident(i: &str) -> IResult<&str, Ident> {
@@ -202,7 +236,8 @@ pub(crate) mod de {
                 terminated(map(section, |(ident, _)| Ident::Section(ident)), opt(eol)),
                 map(key_like, Ident::Key),
             )),
-        )(i)
+        )
+        .parse(i)
     }
 
     pub(crate) fn skip_end(i: &str) -> IResult<&str, &str> {
@@ -210,10 +245,10 @@ pub(crate) mod de {
     }
 
     pub(crate) fn assignment(i: &str) -> IResult<&str, (Option<&str>, char, Option<&str>)> {
-        tuple((opt(space0), char('='), opt(space0)))(i)
+        (opt(space0), char('='), opt(space0)).parse(i)
     }
 
     pub(crate) fn comma(i: &str) -> IResult<&str, (Option<&str>, char, Option<&str>)> {
-        tuple((opt(space0), char(','), opt(space0)))(i)
+        (opt(space0), char(','), opt(space0)).parse(i)
     }
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -53,8 +53,11 @@ fn should_deserialize() {
         e1: Enum,
         e2: Enum,
         e3: Enum,
+        m0: String,
+        m1: String,
     }
 
+    #[rustfmt::skip]
     let input = indoc! {r#"
         b0 = true
         b1 = false
@@ -81,6 +84,15 @@ fn should_deserialize() {
         e1 = thing_b
         e2 = thing_c
         e3 = 3
+
+        m0 = \
+            hello \
+            world
+
+        m1 = \
+            this is a paragraph\
+            \
+            next paragraph
 
         [nested_none]
         n0 = 42
@@ -127,4 +139,6 @@ fn should_deserialize() {
     assert_eq!(Enum::ThingB, test.e1);
     assert_eq!(Enum::ThingC, test.e2);
     assert_eq!(Enum::ThingD, test.e3);
+    assert_eq!("hello world", test.m0);
+    assert_eq!("this is a paragraph\nnext paragraph", test.m1);
 }

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -3,10 +3,19 @@ use ini::{parse_str, Key, Value};
 
 #[test]
 fn should_parse() {
+    #[rustfmt::skip]
     let input = indoc! {r#"
         anon = 42
         boop = hi
         8 = great
+        multi = \
+            hello \
+            world
+        paragraph = \
+            this has a paragraph\
+            \
+            next paragraph
+
         [general]
         foo = bar
         num=42
@@ -49,10 +58,18 @@ fn should_parse() {
 
     // read the anonymous table
     let anon = table.get("_").unwrap();
-    assert_eq!(3, anon.len());
+    assert_eq!(5, anon.len());
     assert_eq!(Some(&Value::Num(42)), anon.get(&Key::Str("anon")));
-    assert_eq!(Some(&Value::Str("hi")), anon.get(&"boop".into()));
-    assert_eq!(Some(&Value::Str("great")), anon.get(&Key::Num(8)));
+    assert_eq!(Some(&Value::Str("hi".into())), anon.get(&"boop".into()));
+    assert_eq!(Some(&Value::Str("great".into())), anon.get(&Key::Num(8)));
+    assert_eq!(
+        Some(&Value::Str("hello world".into())),
+        anon.get(&Key::Str("multi"))
+    );
+    assert_eq!(
+        Some(&Value::Str("this has a paragraph\nnext paragraph".into())),
+        anon.get(&Key::Str("paragraph"))
+    );
 
     // read the empty table
     let empty = table.get("empty").unwrap();
@@ -62,13 +79,13 @@ fn should_parse() {
     for i in ["general", "bar junk", "another"] {
         let map = table.get(i).unwrap();
         assert_eq!(9, map.len());
-        assert_eq!(Some(&Value::Str("bar")), map.get(&"foo".into()));
+        assert_eq!(Some(&Value::Str("bar".into())), map.get(&"foo".into()));
         assert_eq!(Some(&Value::Num(42)), map.get(&"num".into()));
         assert_eq!(Some(&Value::Num(42)), map.get(&"bum".into()));
-        assert_eq!(Some(&Value::Str("world")), map.get(&"a".into()));
-        assert_eq!(Some(&Value::Str("world")), map.get(&"b".into()));
-        assert_eq!(Some(&Value::Str("world")), map.get(&"c".into()));
-        assert_eq!(Some(&Value::Str("tom foo")), map.get(&"d".into()));
+        assert_eq!(Some(&Value::Str("world".into())), map.get(&"a".into()));
+        assert_eq!(Some(&Value::Str("world".into())), map.get(&"b".into()));
+        assert_eq!(Some(&Value::Str("world".into())), map.get(&"c".into()));
+        assert_eq!(Some(&Value::Str("tom foo".into())), map.get(&"d".into()));
         assert_eq!(
             Some(&Value::Array(vec![
                 Value::Num(1),
@@ -79,9 +96,9 @@ fn should_parse() {
         );
         assert_eq!(
             Some(&Value::Array(vec![
-                Value::Str("one"),
-                Value::Str("two"),
-                Value::Str("three")
+                Value::Str("one".into()),
+                Value::Str("two".into()),
+                Value::Str("three".into())
             ])),
             map.get(&"f".into())
         );


### PR DESCRIPTION
This PR distinguishes multiline values, when a value starts with a backslash.  We start with a backslash to avoid ambiguity between a multi line value, vs an array of strings delimited via commas...